### PR TITLE
fix qemu virtiofsd 使用 memory-backend-file,mem-path=/dev/shm 的问题

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ authors = [
     {name = "Wenlei Zhu", email = "i@ztrix.me"},
     {name = "Zhen Tang", email = "tangzhen23@foxmail.com"},
 ]
-version = "0.8.7"
+version = "0.9.0"
 readme = "README.md"
 description = "docker-compose style composer for qemu"
 keywords = ["qemu", "qemu_compose", "qemu-compose"]

--- a/qemu_compose/instance/qemu_runner.py
+++ b/qemu_compose/instance/qemu_runner.py
@@ -490,37 +490,28 @@ class QemuRunner(QEMUMachine):
             if read_only:
                 cmd.append('--readonly')
             try:
+                log_path = os.path.splitext(socket_path)[0] + '.log'
                 logger.info("running virtiofsd %s" % (" ".join(shlex.quote(p) for p in cmd), ))
-                proc = subprocess.Popen(cmd, stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+                logger.info("virtiofsd log path: %s", log_path)
+                with open(log_path, 'ab', buffering=0) as log_fp:
+                    proc = subprocess.Popen(
+                        cmd,
+                        stdin=subprocess.PIPE,
+                        stdout=log_fp,
+                        stderr=subprocess.STDOUT,
+                    )
                 # proc = subprocess.Popen(["/usr/bin/tail", "-f", "/dev/null"], stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
                 return proc
             except Exception as e:
                 logger.warning("failed to start virtiofsd for %s: %s", shared_dir, e)
                 return None
 
-        def drain_proc_output(proc: subprocess.Popen):
-            for s in (proc.stdout, proc.stderr):
-                if s is None:
-                    continue
-                if not s.readable():
-                    continue
-
-                os.set_blocking(s.fileno(), False)
-                try:
-                    line:bytes = s.read(1024)
-                    if line:
-                        logger.debug("virtiofsd: %s", line.decode('utf-8', errors='replace').rstrip())
-                except Exception:
-                    pass
-
         def wait_for_socket(proc: subprocess.Popen, path: str, timeout_sec: float = 3.0, interval_sec: float = 0.05) -> bool:
             deadline = time.time() + timeout_sec
-            drain_proc_output(proc)
             while time.time() < deadline:
                 if os.path.exists(path):
                     return True
                 time.sleep(interval_sec)
-                drain_proc_output(proc)
             return os.path.exists(path)
 
         if self.config.network is None or self.config.network.lower() == 'user':

--- a/qemu_compose/instance/qemu_runner.py
+++ b/qemu_compose/instance/qemu_runner.py
@@ -587,12 +587,12 @@ class QemuRunner(QEMUMachine):
             fstab_entries.append(f"{tag} {dst} virtiofs defaults{ro_suffix} 0 0")
 
         if fstab_entries:
-            # Force use of memory sharing with virtiofsd
-            # see https://github.com/virtio-win/kvm-guest-drivers-windows/wiki/Virtiofs:-Shared-file-system
-
+            # Force use of a shareable guest RAM backend with virtiofsd.
+            # Use memfd instead of /dev/shm-backed files so the VM is not capped
+            # by the tmpfs mount size of /dev/shm.
             args.extend([
                 "-object",
-                "memory-backend-file,id=qc-mem,size=%s,mem-path=/dev/shm,share=on" % vm_mem_size,
+                "memory-backend-memfd,id=qc-mem,size=%s,share=on" % vm_mem_size,
                 "-numa",
                 "node,memdev=qc-mem",
             ])

--- a/qemu_compose/main.py
+++ b/qemu_compose/main.py
@@ -63,7 +63,7 @@ def guess_conf_path(p:str | None):
     return None
 
 def version(short=False):
-    version = "v0.8.7"
+    version = "v0.9.0"
     if short:
         print(version, file=sys.stderr)
     else:


### PR DESCRIPTION
• 我把当前活跃 VM 的 /dev/shm 实占也拿到了。现在证据已经相当接近“容量问题”了，只差一个会不会触发故障的主动复现实验。那个实验有把某台 VM 压崩的风险，所以我先把现有结论给你。

• 现有验证结果已经很支持“/dev/shm 容量问题”这个方向。

  宿主当前状态是：

  - /dev/shm 总大小只有 32G
  - 当前已用 23G，只剩 8.7G
  - 同时运行的 QEMU VM 声明内存总和是 56G
  - 这些 VM 的主内存后端全部在 /dev/shm/qemu_back_mem.* (deleted)

  我把每台活跃 VM 的共享内存实际占用也算出来了：

  - mql: mem=8G，rss_shmem=8.0GiB
  - knowall: mem=16G，rss_shmem=6.8GiB
  - miner: mem=8G，rss_shmem=4.6GiB
  - devboard: mem=8G，rss_shmem=1.7GiB
  - qzh: mem=16G，rss_shmem=1.6GiB

  合计实际已经触达的共享内存是 22.7G。这和宿主 Shmem/df /dev/shm 基本对得上。

  这说明两件事：

  1. 这套 VM 确实把 guest RAM 放在 /dev/shm 上。
  2. 当前只剩 8.7G 余量，而还有几台 VM 远没触达到各自声明的内存上限，所以它们继续运行时，完全可能在“又多碰到几 GB 页”之后把 /dev/shm 顶满，然后触发你看到的 kvm run failed Bad address。

  再结合之前已经查到的事实：

  - 至少 build-devbox、board-devbox、crm 三台不同 VM 都报过同样的错
  - 都是 qemu-compose
  - 都用了 memory-backend-file,mem-path=/dev/shm,share=on

  这个模式已经很不像 guest 自身问题，更像宿主共享内存后端被顶到边界后的系统性故障。

  现在的判断

  我认为“/dev/shm 太小/被并发 VM 挤爆”已经是高概率根因。

  如果你想继续做强验证

  可以做一个可控实验，但有风险：

  - 选一台不重要的 VM
  - 在 guest 里主动分配并触碰几 GB 内存
  - 同时在宿主盯着 df -h /dev/shm
  - 如果 /dev/shm 逼近 100% 后复现 kvm run failed Bad address，就能基本坐实