### PR TITLE
feat: add qemu-compose tag command for image tagging

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,3 +97,39 @@ $ qemu-compose down --force my-vm
 ```
 
 Note: If no identifier is provided, qemu-compose will look for `qemu-compose.yml` or `qemu-compose.yaml` in the current directory and use the `name` field as the instance identifier.
+
+## Tag Command
+
+Create a tag that refers to an image, similar to `docker tag`.
+
+```
+$ qemu-compose tag SOURCE_IMAGE[:TAG] TARGET_IMAGE[:TAG]
+```
+
+- `SOURCE_IMAGE[:TAG]`: Source image identifier (can be image ID, name, or name:tag)
+- `TARGET_IMAGE[:TAG]`: Target image name and optional tag (defaults to `latest` if not specified)
+
+Behavior:
+- If the target tag already exists on another image, it will be moved to the source image
+- Tags are stored in the image's `manifest.json` file under the `repo_tags` field
+
+Examples:
+
+```
+# Tag an image by ID
+$ qemu-compose tag 94a0434d0f73 devbox:archlinux
+
+# Tag an image by name
+$ qemu-compose tag my-image:v1 my-image:latest
+
+# Create a new tag for an existing image
+$ qemu-compose tag ubuntu:20.04 ubuntu:focal
+
+# Replace an existing tag (moves tag from one image to another)
+$ qemu-compose tag new-image:v1 existing-tag:latest
+```
+
+Notes:
+- Image IDs can be specified as full SHA256 digest or unique prefix
+- When a tag already exists on a different image, the tag is moved (not copied) to the new image
+- Use `qemu-compose images` to list all images and their tags

--- a/qemu_compose/cmd/tag_command.py
+++ b/qemu_compose/cmd/tag_command.py
@@ -1,0 +1,102 @@
+from __future__ import annotations
+import argparse
+import json
+import os
+import sys
+from typing import List, Optional, Tuple
+
+from qemu_compose.local_store import LocalStore
+from qemu_compose.image import list_image, load_image_by_name, resolve_image, resolve_image_by_prefix
+from qemu_compose.image.manifest import ImageManifest, RepoTag
+
+
+def find_image_by_id_or_name(image_root: str, token: str) -> Tuple[Optional[str], List[str]]:
+    """
+    Resolve an image identifier (ID prefix, name:tag, or name) to a unique image ID.
+    Returns (matched_id, all_candidate_ids).
+    """
+    # First try exact name:tag match via load_image_by_name
+    if (found := load_image_by_name(image_root, token)):
+        return found.id, [found.id]
+
+    # Try as ID prefix
+    matched_id, candidates = resolve_image_by_prefix(image_root, token)
+    if matched_id:
+        return matched_id, candidates
+
+    return None, []
+
+
+def update_manifest_repo_tags(manifest_path: str, new_repo_tags: List[RepoTag]) -> None:
+    """
+    Load manifest.json, replace repo_tags with new_repo_tags, and write back.
+    """
+    with open(manifest_path, 'r') as f:
+        obj = json.load(f)
+
+    obj['repo_tags'] = [f"{rt.repo}:{rt.tag}" for rt in new_repo_tags]
+
+    with open(manifest_path, 'w') as f:
+        json.dump(obj, f, indent=2)
+        f.write('\n')
+
+
+def command_tag(source_image: str, target_image: str, force: bool = False) -> int:
+    """
+    Create a tag TARGET_IMAGE that refers to SOURCE_IMAGE.
+    
+    If the target tag already exists:
+    - Default behavior is to replace it (force=True behavior)
+    """
+    store = LocalStore()
+    image_root = store.image_root
+
+    # Resolve source image to its actual ID
+    source_id, source_candidates = find_image_by_id_or_name(image_root, source_image)
+    if source_id is None:
+        if not source_candidates:
+            print(f"Error: source image not found: '{source_image}'", file=sys.stderr)
+        else:
+            preview = ", ".join(sorted(source_candidates)[:8])
+            more = "" if len(source_candidates) <= 8 else f" ... and {len(source_candidates)-8} more"
+            print(f"Error: source image '{source_image}' is ambiguous; matches: {preview}{more}", file=sys.stderr)
+        return 1
+
+    # Load source manifest
+    source_manifest_path = os.path.join(image_root, source_id, "manifest.json")
+    source_manifest = ImageManifest.load_file(os.path.join(image_root, source_id))
+
+    # Parse target image name:tag
+    target_rt = RepoTag.from_str(target_image)
+
+    # Check if target tag already exists on a different image
+    existing_target_id = None
+    for image_id in os.listdir(image_root):
+        image_dir = os.path.join(image_root, image_id)
+        if not os.path.isdir(image_dir):
+            continue
+        manifest = ImageManifest.load_file(image_dir)
+        if manifest.has_repo_tag(target_image) and image_id != source_id:
+            existing_target_id = image_id
+            break
+
+    if existing_target_id is not None:
+        # Tag exists on different image - replace it by removing from old image
+        existing_manifest_path = os.path.join(image_root, existing_target_id, "manifest.json")
+        existing_manifest = ImageManifest.load_file(os.path.join(image_root, existing_target_id))
+        
+        # Remove the target tag from the existing image
+        new_existing_tags = [rt for rt in existing_manifest.repo_tags if not rt.match_name(target_image)]
+        update_manifest_repo_tags(existing_manifest_path, new_existing_tags)
+
+    # Add the new tag to the source image
+    if not any(rt.match_name(target_image) for rt in source_manifest.repo_tags):
+        new_source_tags = list(source_manifest.repo_tags) + [target_rt]
+        update_manifest_repo_tags(source_manifest_path, new_source_tags)
+    
+    # Print the operation result
+    source_id_short = source_manifest.id.split(":")[1][:12] if ":" in source_manifest.id else source_manifest.id[:12]
+    print(f"Image: {source_id_short}")
+    print(f"Tagged: {target_rt.repo}:{target_rt.tag}")
+    
+    return 0

--- a/qemu_compose/main.py
+++ b/qemu_compose/main.py
@@ -3,6 +3,7 @@ from typing import List, Optional
 import os
 import shlex
 import sys
+import argparse
 import yaml
 import logging
 
@@ -75,7 +76,7 @@ def cli():
         formatter_class=argparse.RawDescriptionHelpFormatter,
         description="Define and run QEMU VM with qemu",
         usage="qemu-compose [OPTIONS] COMMAND",
-epilog="""Commands:
+ epilog="""Commands:
   up          Create and start QEMU vm
   ssh         Run ssh with instance key
   ps          List VM instances
@@ -84,13 +85,30 @@ epilog="""Commands:
   run         Create and run a new VM from an image
   start       Start an existing VM instance by ID or name
   down        Stop and remove a VM instance
+  tag         Create a tag TARGET_IMAGE that refers to SOURCE_IMAGE
  """,
     )
     parser.add_argument("-v", "--version", action="store_true", help="Show the qemu-compose version information")
     parser.add_argument("--short", action="store_true", default=False, help="Shows only qemu-compose's version number")
     parser.add_argument('command', type=str, nargs='?', help='command to run')
+    
+    # Check for subcommand help before parse_known_args
+    help_flag = None
+    if '--help' in sys.argv:
+        help_flag = '--help'
+    elif '-h' in sys.argv:
+        help_flag = '-h'
+    
+    if help_flag:
+        # Remove from sys.argv temporarily to let subcommand parser handle it
+        sys.argv.remove(help_flag)
+    
     # Parse only known top-level args, leave subcommand options for later
     args, rest = parser.parse_known_args()
+    
+    # Restore help flag for subcommand parser
+    if help_flag:
+        rest.append(help_flag)
 
     if args.command == "version" or (args.version and not args.command):
         version(short=args.short)
@@ -364,6 +382,27 @@ epilog="""Commands:
 
         from .cmd.down_command import command_down
         sys.exit(command_down(identifier=down_args.identifier, force=down_args.force, config_path=config_path))
+    elif args.command == "tag":
+        import argparse as _argparse
+        tag_parser = _argparse.ArgumentParser(
+            prog="qemu-compose tag",
+            add_help=True,
+            description="Create a tag TARGET_IMAGE that refers to SOURCE_IMAGE",
+        )
+        tag_parser.add_argument(
+            "source_image",
+            type=str,
+            help="Source image identifier (ID or name[:tag])",
+        )
+        tag_parser.add_argument(
+            "target_image",
+            type=str,
+            help="Target image name[:tag]",
+        )
+        tag_args = tag_parser.parse_args(rest)
+
+        from .cmd.tag_command import command_tag
+        sys.exit(command_tag(source_image=tag_args.source_image, target_image=tag_args.target_image))
     else:
         parser.print_help()
         sys.exit(1)


### PR DESCRIPTION
- Implement tag command similar to docker tag functionality
- Support tagging images by ID, name, or name:tag
- Automatically move tags when target tag already exists on another image
- Store tags in manifest.json repo_tags field
- Add comprehensive documentation and examples
- Include help text and error handling