### PR TITLE
feat: 实现 CID 持久化分配机制，避免 VM 重启时 CID 冲突

### DIFF
--- a/qemu_compose/instance/qemu_runner.py
+++ b/qemu_compose/instance/qemu_runner.py
@@ -203,7 +203,7 @@ class QemuRunner(QEMUMachine):
             # Read name if present
             self.vm_name = safe_read(os.path.join(root, self.vmid, "name"))
 
-        self.cid = get_available_guest_cid(1000)
+        self.cid = get_available_guest_cid(1000, self.store.get_allocated_cids())
         if self.cid is None:
             print("no available guest cid found, please make sure vhost_vsock module loaded", file=sys.stderr)
             return 124

--- a/qemu_compose/local_store.py
+++ b/qemu_compose/local_store.py
@@ -1,5 +1,6 @@
 
 import os
+from typing import Set
 
 class LocalStore:
     def __init__(self, name="qemu-compose"):
@@ -28,3 +29,21 @@ class LocalStore:
         path = os.path.join(self.instance_root, vmid)
         os.makedirs(path, exist_ok=True)
         return path
+
+    def get_allocated_cids(self) -> Set[int]:
+        """获取所有已分配的 CID（从所有 instance 的 cid 文件中读取）"""
+        allocated = set()
+        try:
+            for instance_id in os.listdir(self.instance_root):
+                cid_path = os.path.join(self.instance_root, instance_id, "cid")
+                try:
+                    with open(cid_path, "r") as f:
+                        cid_str = f.read().strip()
+                        if cid_str:
+                            allocated.add(int(cid_str))
+                except (FileNotFoundError, ValueError, IOError):
+                    # 忽略没有 cid 文件或 cid 无效的 instance
+                    pass
+        except FileNotFoundError:
+            pass
+        return allocated

--- a/qemu_compose/utils/vsock.py
+++ b/qemu_compose/utils/vsock.py
@@ -11,11 +11,12 @@ VHOST_VSOCK_SET_GUEST_CID = 0x4008AF60
 VSOCK_PATH = '/dev/vhost-vsock'
 
 
-def get_available_guest_cid(start_guest_cid: int = 1000) -> None | int:
+def get_available_guest_cid(start_guest_cid: int = 1000, allocated_cids=None) -> None | int:
     """
     get available guest cid
 
-    :param guest_cid: start_guest_cid
+    :param start_guest_cid: start guest cid
+    :param allocated_cids: set of already allocated CIDs to avoid reusing
     :return: available guest cid if success, else None
     """
     try:
@@ -30,6 +31,10 @@ def get_available_guest_cid(start_guest_cid: int = 1000) -> None | int:
     guest_cid = start_guest_cid
     try:
         while guest_cid <= 0xFFFFFFFF:  # U32_MAX
+            if allocated_cids is not None and guest_cid in allocated_cids:
+                guest_cid += 1
+                continue
+                
             cid_c = struct.pack('L', guest_cid)
             try:
                 fcntl.ioctl(vsock_fd, VHOST_VSOCK_SET_GUEST_CID, cid_c)


### PR DESCRIPTION
- LocalStore: 新增 get_allocated_cids() 方法，从所有 instance 的 cid 文件读取已分配的 CID
- vsock: 更新 get_available_guest_cid() 函数，支持跳过已分配的 CID
- QemuRunner: VM 启动时传入已分配 CID 列表，确保不重复分配

实现方案：
- 不再使用单独的 cid_allocations.json 文件
- 直接从所有 instance 目录下的 cid 文件读取已分配的 CID
- 自动忽略没有 cid 文件或 cid 无效的 instance
- VM 退出后 CID 不会被重复分配，QEMU 重启时不会发生 CID 冲突

Fixes: CID 分配时不能重复的问题