### PR TITLE
fix: 重启已有 instance 时优先复用原有 CID

### DIFF
--- a/qemu_compose/instance/qemu_runner.py
+++ b/qemu_compose/instance/qemu_runner.py
@@ -203,7 +203,32 @@ class QemuRunner(QEMUMachine):
             # Read name if present
             self.vm_name = safe_read(os.path.join(root, self.vmid, "name"))
 
-        self.cid = get_available_guest_cid(1000, self.store.get_allocated_cids())
+        # 获取已分配的 CID 列表（用于避免冲突）
+        allocated_cids = self.store.get_allocated_cids()
+        
+        # 如果是重启已有 instance，尝试复用原来的 CID
+        self.cid = None
+        if self.config.instance is not None:
+            existing_cid_path = os.path.join(self.store.instance_dir(self.vmid), "cid")
+            try:
+                with open(existing_cid_path, "r") as f:
+                    existing_cid_str = f.read().strip()
+                    if existing_cid_str:
+                        existing_cid = int(existing_cid_str)
+                        # 尝试复用这个 CID，从它开始查找
+                        self.cid = get_available_guest_cid(existing_cid, allocated_cids - {existing_cid})
+                        # 如果找到的 CID 不是原来的，说明原来的被系统占用了
+                        if self.cid != existing_cid:
+                            logger.info("existing CID %d is in use by system, allocating new CID %d", 
+                                      existing_cid, self.cid)
+            except (FileNotFoundError, ValueError, IOError):
+                # cid 文件不存在或无效，使用普通分配流程
+                pass
+        
+        # 如果是新 instance 或复用失败，使用普通分配流程
+        if self.cid is None:
+            self.cid = get_available_guest_cid(1000, allocated_cids)
+        
         if self.cid is None:
             print("no available guest cid found, please make sure vhost_vsock module loaded", file=sys.stderr)
             return 124


### PR DESCRIPTION
问题：
- 之前每次重启已有 instance 都会分配新 CID
- 导致同一个 instance 多次重启后 CID 变化
- 也导致原有 CID 可能被其他 instance 占用

解决方案：
- 当 config.instance != None 时，读取原有的 cid 文件
- 从原有 CID 开始查找，并从 allocated 集合中排除该 CID
- 成功复用则使用原有 CID
- 只有当原有 CID 被系统占用时（ioctl 返回 EADDRINUSE），才分配新 CID
- 新 instance 仍然使用原有的分配流程（从 1000 开始）

影响：
- 已有 instance 重启后保持 CID 不变
- 避免 CID 频繁变化导致的问题
- 保持 CID 持久化分配的核心功能