### PR TITLE
feat: ssh command can omit identifier when qemu-compose.yml exists

### DIFF
--- a/qemu_compose/cmd/ssh_command.py
+++ b/qemu_compose/cmd/ssh_command.py
@@ -65,13 +65,35 @@ def _build_ssh_cmd(root: str, vmid: str, passthrough: List[str]) -> tuple[List[s
     return base + [destination] + passthrough, cid_val
 
 
-def command_ssh(*, identifier: str, passthrough: Optional[List[str]] = None) -> int:
+def command_ssh(*, identifier: Optional[str] = None, passthrough: Optional[List[str]] = None, config_path: Optional[str] = None) -> int:
     store = LocalStore()
     instance_root = store.instance_root
 
     name_index = _build_name_index(instance_root)
     ids = _list_vmids(instance_root)
-    vmid, candidates = _resolve_identifier_with_prefix(identifier, ids, name_index)
+
+    vmid = None
+    candidates = []
+
+    if identifier:
+        vmid, candidates = _resolve_identifier_with_prefix(identifier, ids, name_index)
+    elif config_path:
+        import yaml
+        try:
+            with open(config_path) as f:
+                config_obj = yaml.safe_load(f)
+            config_name = config_obj.get("name") if config_obj else None
+            if config_name:
+                vmid, candidates = _resolve_identifier_with_prefix(config_name, ids, name_index)
+            else:
+                print("Error: config file does not specify a name", file=sys.stderr)
+                return 1
+        except Exception as e:
+            print(f"Error: failed to read config file: {e}", file=sys.stderr)
+            return 1
+    else:
+        print("Error: identifier is required", file=sys.stderr)
+        return 1
 
     if vmid is None and not candidates:
         print("Error: no VMID or NAME matches the given prefix.", file=sys.stderr)

--- a/qemu_compose/main.py
+++ b/qemu_compose/main.py
@@ -105,6 +105,7 @@ def cli():
         ssh_parser.add_argument(
             "identifier",
             type=str,
+            nargs='?',
             help="Instance ID, unique prefix, or assigned name",
         )
         ssh_parser.add_argument(
@@ -117,7 +118,8 @@ def cli():
 
         from .cmd.ssh_command import command_ssh
 
-        sys.exit(command_ssh(identifier=ssh_args.identifier, passthrough=ssh_args.command))
+        config_path = guess_conf_path(None)
+        sys.exit(command_ssh(identifier=ssh_args.identifier, passthrough=ssh_args.command, config_path=config_path))
     elif args.command == "ps":
         import argparse as _argparse
         # Sub-parser for `ps` options to keep scope minimal

--- a/tests/test_ssh_command.py
+++ b/tests/test_ssh_command.py
@@ -1,0 +1,69 @@
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+from qemu_compose.cmd.ssh_command import command_ssh
+
+
+def test_ssh_with_identifier(tmp_path, monkeypatch, capsys):
+    """Test ssh with explicit identifier works."""
+    monkeypatch.setenv("XDG_DATA_HOME", str(tmp_path))
+    instance_root = tmp_path / "qemu-compose" / "instance"
+    vmid = "vm-12345678"
+    instance_dir = instance_root / vmid
+    instance_dir.mkdir(parents=True)
+    (instance_dir / "name").write_text("my-vm")
+    (instance_dir / "ssh-key").write_text("fake-key")
+    (instance_dir / "cid").write_text("1001")
+
+    # Should resolve by name and return 127 (ssh not found in test env)
+    assert command_ssh(identifier="my-vm") == 127
+
+
+def test_ssh_without_identifier_reads_config_name(tmp_path, monkeypatch, capsys):
+    """Test ssh without identifier reads name from qemu-compose.yml."""
+    monkeypatch.setenv("XDG_DATA_HOME", str(tmp_path))
+    instance_root = tmp_path / "qemu-compose" / "instance"
+    vmid = "vm-12345678"
+    instance_dir = instance_root / vmid
+    instance_dir.mkdir(parents=True)
+    (instance_dir / "name").write_text("ubuntu__cloudimg")
+    (instance_dir / "ssh-key").write_text("fake-key")
+    (instance_dir / "cid").write_text("1001")
+
+    config_path = tmp_path / "qemu-compose.yml"
+    config_path.write_text("name: ubuntu__cloudimg\n")
+
+    # Should resolve by config name and return 127 (ssh not found in test env)
+    assert command_ssh(config_path=str(config_path)) == 127
+
+
+def test_ssh_without_identifier_no_config(tmp_path, monkeypatch, capsys):
+    """Test ssh without identifier and no config fails."""
+    monkeypatch.setenv("XDG_DATA_HOME", str(tmp_path))
+
+    assert command_ssh() == 1
+    assert "identifier is required" in capsys.readouterr().err
+
+
+def test_ssh_config_without_name(tmp_path, monkeypatch, capsys):
+    """Test ssh with config that has no name fails."""
+    monkeypatch.setenv("XDG_DATA_HOME", str(tmp_path))
+
+    config_path = tmp_path / "qemu-compose.yml"
+    config_path.write_text("env:\n  foo: bar\n")
+
+    assert command_ssh(config_path=str(config_path)) == 1
+    assert "does not specify a name" in capsys.readouterr().err
+
+
+def test_ssh_config_name_no_matching_instance(tmp_path, monkeypatch, capsys):
+    """Test ssh with config name that doesn't match any instance fails."""
+    monkeypatch.setenv("XDG_DATA_HOME", str(tmp_path))
+
+    config_path = tmp_path / "qemu-compose.yml"
+    config_path.write_text("name: nonexistent\n")
+
+    assert command_ssh(config_path=str(config_path)) == 1
+    assert "no VMID or NAME matches" in capsys.readouterr().err


### PR DESCRIPTION
## Summary

When a `qemu-compose.yml` file is present in the current directory, users can now run `qemu-compose ssh` without specifying an identifier. The command will automatically read the `name` field from the `qemu-compose.yml` config file to resolve the target VM instance.

## Changes

- `qemu_compose/main.py`: Made `identifier` argument optional for `ssh` subcommand; automatically look up `qemu-compose.yml` in current directory.
- `qemu_compose/cmd/ssh_command.py`: Added `config_path` parameter; when `identifier` is omitted, parse the YAML config to extract `name` and resolve the VM instance.
- `tests/test_ssh_command.py`: Added 5 unit tests covering the new logic.

## Affected Modules/Paths

- `qemu_compose/main.py`
- `qemu_compose/cmd/ssh_command.py`
- `tests/test_ssh_command.py`

## Demo

```bash
# Before (still works)
qemu-compose ssh ubuntu__cloudimg

# After (new shortcut)
qemu-compose ssh